### PR TITLE
fix issue #3 -- Linux kernel thinks nlink 0 means invalid inode

### DIFF
--- a/src/demofs.rs
+++ b/src/demofs.rs
@@ -26,7 +26,7 @@ fn make_file(name: &str, id: fileid3, parent: fileid3, contents: &[u8]) -> FSEnt
     let attr = fattr3 {
         ftype: ftype3::NF3REG,
         mode: 0o755,
-        nlink: 0,
+        nlink: 1,
         uid: 507,
         gid: 507,
         size: contents.len() as u64,
@@ -51,7 +51,7 @@ fn make_dir(name: &str, id: fileid3, parent: fileid3, contents: Vec<fileid3>) ->
     let attr = fattr3 {
         ftype: ftype3::NF3DIR,
         mode: 0o777,
-        nlink: 0,
+        nlink: 1,
         uid: 507,
         gid: 507,
         size: 0,


### PR DESCRIPTION
Linux appears to be having a problem with the `fattr3` returned with `nlink` set to 0 for the root of the NFS mount. Once that's changed, it works.

Guessing, because changing the hardcoded `nlink` value from 0 to 1 makes it work, that Linux is thinking the inode was deleted.