### PR TITLE
impl Display for nfsstring

### DIFF
--- a/src/nfs.rs
+++ b/src/nfs.rs
@@ -76,6 +76,11 @@ impl fmt::Debug for nfsstring {
         write!(f, "{:?}", String::from_utf8_lossy(&self.0))
     }
 }
+impl fmt::Display for nfsstring {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", String::from_utf8_lossy(&self.0))
+    }
+}
 pub type opaque = u8;
 pub type filename3 = nfsstring;
 pub type nfspath3 = nfsstring;


### PR DESCRIPTION
I would expect a string to be printable by using `println!("{the_string}");` so I implemented `fmt::Display` for nfsstring.