### PR TITLE
default readdir implementation based on readdirplus

### DIFF
--- a/src/nfs_handlers.rs
+++ b/src/nfs_handlers.rs
@@ -140,6 +140,7 @@ pub async fn handle_nfs(
         NFSProgram::NFSPROC3_ACCESS => nfsproc3_access(xid, input, output, context).await?,
         NFSProgram::NFSPROC3_PATHCONF => nfsproc3_pathconf(xid, input, output, context).await?,
         NFSProgram::NFSPROC3_FSSTAT => nfsproc3_fsstat(xid, input, output, context).await?,
+        NFSProgram::NFSPROC3_READDIR => nfsproc3_readdir(xid, input, output, context).await?,
         NFSProgram::NFSPROC3_READDIRPLUS => {
             nfsproc3_readdirplus(xid, input, output, context).await?
         }
@@ -158,7 +159,6 @@ pub async fn handle_nfs(
         } /*
           NFSPROC3_MKNOD,
           NFSPROC3_LINK,
-          NFSPROC3_READDIR,
           NFSPROC3_COMMIT,
           INVALID*/
     }
@@ -788,6 +788,36 @@ XDRStruct!(
 
 #[allow(non_camel_case_types)]
 #[derive(Debug, Default)]
+struct entry3 {
+    fileid: nfs::fileid3,
+    name: nfs::filename3,
+    cookie: nfs::cookie3
+}
+XDRStruct!(
+    entry3,
+    fileid,
+    name,
+    cookie
+);
+
+#[allow(non_camel_case_types)]
+#[derive(Debug, Default)]
+struct READDIR3args {
+    dir: nfs::nfs_fh3,
+    cookie: nfs::cookie3,
+    cookieverf: nfs::cookieverf3,
+    dircount: nfs::count3
+}
+XDRStruct!(
+    READDIR3args,
+    dir,
+    cookie,
+    cookieverf,
+    dircount
+);
+
+#[allow(non_camel_case_types)]
+#[derive(Debug, Default)]
 struct entryplus3 {
     fileid: nfs::fileid3,
     name: nfs::filename3,
@@ -988,6 +1018,127 @@ pub async fn nfsproc3_readdirplus(
                         "  -- lengths: {:?} / {:?} {:?} / {:?}",
                         accumulated_dircount,
                         max_dircount_bytes,
+                        counting_output.bytes_written(),
+                        max_bytes_allowed
+                    );
+                } else {
+                    trace!(" -- insufficient space. truncating");
+                    all_entries_written = false;
+                    break;
+                }
+            }
+            // false flag for the final entryplus* linked list
+            false.serialize(&mut counting_output)?;
+            // eof flag is only valid here if we wrote everything
+            if all_entries_written {
+                debug!("  -- readdir eof {:?}", result.end);
+                result.end.serialize(&mut counting_output)?;
+            } else {
+                debug!("  -- readdir eof {:?}", false);
+                false.serialize(&mut counting_output)?;
+            }
+            debug!(
+                "readir {}, has_version {},  start at {}, flushing {} entries, complete {}",
+                dirid, has_version, args.cookie, ctr, all_entries_written
+            );
+        }
+        Err(stat) => {
+            error!("readdir error {:?} --> {:?} ", xid, stat);
+            make_success_reply(xid).serialize(output)?;
+            stat.serialize(output)?;
+            dir_attr.serialize(output)?;
+        }
+    };
+    Ok(())
+}
+
+pub async fn nfsproc3_readdir(
+    xid: u32,
+    input: &mut impl Read,
+    output: &mut impl Write,
+    context: &RPCContext,
+) -> Result<(), anyhow::Error> {
+    let mut args = READDIR3args::default();
+    args.deserialize(input)?;
+    debug!("nfsproc3_readdirplus({:?},{:?}) ", xid, args);
+
+    let dirid = context.vfs.fh_to_id(&args.dir);
+    // fail if unable to convert file handle
+    if let Err(stat) = dirid {
+        make_success_reply(xid).serialize(output)?;
+        stat.serialize(output)?;
+        nfs::post_op_attr::Void.serialize(output)?;
+        return Ok(());
+    }
+    let dirid = dirid.unwrap();
+    let dir_attr_maybe = context.vfs.getattr(dirid).await;
+
+    let dir_attr = match dir_attr_maybe {
+        Ok(v) => nfs::post_op_attr::attributes(v),
+        Err(_) => nfs::post_op_attr::Void,
+    };
+
+    let dirversion = if let Ok(ref dir_attr) = dir_attr_maybe {
+        let cvf_version = (dir_attr.mtime.seconds as u64) << 32 | (dir_attr.mtime.nseconds as u64);
+        cvf_version.to_be_bytes()
+    } else {
+        nfs::cookieverf3::default()
+    };
+    debug!(" -- Dir attr {:?}", dir_attr);
+    debug!(" -- Dir version {:?}", dirversion);
+    let has_version = args.cookieverf != nfs::cookieverf3::default();
+    // subtract off the final entryplus* field (which must be false) and the eof
+    let max_bytes_allowed = args.dircount as usize - 128;
+    // args.dircount is bytes of just fileid, name, cookie.
+    // This is hard to ballpark, so we just divide it by 16
+    let estimated_max_results = args.dircount / 16;
+    let mut ctr = 0;
+    match context
+        .vfs
+        .readdir_simple(dirid, estimated_max_results as usize)
+        .await
+    {
+        Ok(result) => {
+            // we count dir_count seperately as it is just a subset of fields
+            let mut accumulated_dircount: usize = 0;
+            let mut all_entries_written = true;
+
+            // this is a wrapper around a writer that also just counts the number of bytes
+            // written
+            let mut counting_output = crate::write_counter::WriteCounter::new(output);
+
+            make_success_reply(xid).serialize(&mut counting_output)?;
+            nfs::nfsstat3::NFS3_OK.serialize(&mut counting_output)?;
+            dir_attr.serialize(&mut counting_output)?;
+            dirversion.serialize(&mut counting_output)?;
+            for entry in result.entries {
+                let entry = entry3 {
+                    fileid: entry.fileid,
+                    name: entry.name,
+                    cookie: entry.fileid
+                };
+                // write the entry into a buffer first
+                let mut write_buf: Vec<u8> = Vec::new();
+                let mut write_cursor = std::io::Cursor::new(&mut write_buf);
+                // true flag for the entryplus3* to mark that this contains an entry
+                true.serialize(&mut write_cursor)?;
+                entry.serialize(&mut write_cursor)?;
+                write_cursor.flush()?;
+                let added_dircount = std::mem::size_of::<nfs::fileid3>()                   // fileid
+                                    + std::mem::size_of::<u32>() + entry.name.len()  // name
+                                    + std::mem::size_of::<nfs::cookie3>(); // cookie
+                let added_output_bytes = write_buf.len();
+                // check if we can write without hitting the limits
+                if added_output_bytes + counting_output.bytes_written() < max_bytes_allowed
+                {
+                    trace!("  -- dirent {:?}", entry);
+                    // commit the entry
+                    ctr += 1;
+                    counting_output.write_all(&write_buf)?;
+                    accumulated_dircount += added_dircount;
+                    trace!(
+                        "  -- lengths: {:?} / {:?} / {:?}",
+                        accumulated_dircount,
                         counting_output.bytes_written(),
                         max_bytes_allowed
                     );


### PR DESCRIPTION
Provide a default readdir implementation based on readdirplus. The new NFS trait method is named `readdir_simple` for compatibility reasons. User can provide dedicated implementation if performance is critical.

During testing, we found out that NFS client on ArchLinux will call `readdir` on each subdirectory on parent dir `readdirplus` call.