### PR TITLE
Fix for cargo publish

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,9 @@ demo = ["tracing-subscriber", "tokio/rt-multi-thread", "intaglio"]
 [[example]]
 name = "demo"
 required-features = ["demo"]
+path = "examples/demo.rs"
 
 [[example]]
 name = "mirrorfs"
 required-features = ["demo"]
+path = "examples/mirrorfs.rs"


### PR DESCRIPTION
Without the path specified, there was an error
```
cargo publish --dry-run
error: failed to verify package tarball

Caused by:
  can't find `demo` example at `examples/demo.rs` or
  `examples/demo/main.rs`. Please specify example.path if you want to
  use a non-default path.
```