### PR TITLE
introduce extended filesystem interface

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -1,4 +1,4 @@
-use crate::vfs::NFSFileSystem;
+use crate::vfsext::NFSFileSystemExtended;
 use std::fmt;
 use std::sync::Arc;
 use tokio::sync::mpsc;
@@ -7,7 +7,7 @@ pub struct RPCContext {
     pub local_port: u16,
     pub client_addr: String,
     pub auth: crate::rpc::auth_unix,
-    pub vfs: Arc<dyn NFSFileSystem + Send + Sync>,
+    pub vfs: Arc<dyn NFSFileSystemExtended + Send + Sync>,
     pub mount_signal: Option<mpsc::Sender<bool>>,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,3 +20,5 @@ pub mod fs_util;
 
 pub mod tcp;
 pub mod vfs;
+pub mod vfsext;
+pub mod vfsextimpl;

--- a/src/nfs.rs
+++ b/src/nfs.rs
@@ -279,6 +279,16 @@ XDRStruct!(
     fattr3, ftype, mode, nlink, uid, gid, size, used, rdev, fsid, fileid, atime, mtime, ctime
 );
 
+// section 3.3.4 Procedure 4 ACCESS - Check Access Permission
+// The following constants are used in ACCESS for use within a permission bitmask.
+pub const ACCESS3_READ: u32 = 0x0001;
+pub const ACCESS3_LOOKUP: u32 = 0x0002;
+pub const ACCESS3_MODIFY: u32 = 0x0004;
+pub const ACCESS3_EXTEND: u32 = 0x0008;
+pub const ACCESS3_DELETE: u32 = 0x0010;
+pub const ACCESS3_EXECUTE: u32 = 0x0020;
+
+
 // Section 3.3.19. Procedure 19: FSINFO - Get static file system Information
 // The following constants are used in fsinfo to construct the bitmask 'properties',
 // which represents the file system properties.

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -76,9 +76,9 @@ pub enum auth_stat {
     AUTH_BADCRED = 1,
     /// client must begin new session
     AUTH_REJECTEDCRED = 2,
-    /// bad verifier (seal broken)    
+    /// bad verifier (seal broken)
     AUTH_BADVERF = 3,
-    /// verifier expired or replayed  
+    /// verifier expired or replayed
     AUTH_REJECTEDVERF = 4,
     /// rejected for security reasons
     AUTH_TOOWEAK = 5,
@@ -100,11 +100,11 @@ XDREnumSerde!(auth_flavor);
 #[allow(non_camel_case_types)]
 #[derive(Clone, Debug, Default)]
 pub struct auth_unix {
-    stamp: u32,
-    machinename: Vec<u8>,
-    uid: u32,
-    gid: u32,
-    gids: Vec<u32>,
+    pub stamp: u32,
+    pub machinename: Vec<u8>,
+    pub uid: u32,
+    pub gid: u32,
+    pub gids: Vec<u32>,
 }
 XDRStruct!(auth_unix, stamp, machinename, uid, gid, gids);
 

--- a/src/vfsext.rs
+++ b/src/vfsext.rs
@@ -1,100 +1,32 @@
 use crate::nfs::*;
 use crate::nfs;
+use crate::vfs::*;
+use crate::rpc::auth_unix;
+
 use async_trait::async_trait;
-use std::cmp::Ordering;
-use std::sync::Once;
-use std::time::SystemTime;
-#[derive(Default, Debug)]
-pub struct DirEntrySimple {
-    pub fileid: fileid3,
-    pub name: filename3,
-}
-#[derive(Default, Debug)]
-pub struct ReadDirSimpleResult {
-    pub entries: Vec<DirEntrySimple>,
-    pub end: bool,
+
+#[derive(Clone, Debug, Default)]
+pub struct UserContext {
+    _uid: u32,
+    _gid: u32,
+    _gids: Vec<u32>,
 }
 
-#[derive(Default, Debug)]
-pub struct DirEntry {
-    pub fileid: fileid3,
-    pub name: filename3,
-    pub attr: fattr3,
-}
-#[derive(Default, Debug)]
-pub struct ReadDirResult {
-    pub entries: Vec<DirEntry>,
-    pub end: bool,
-}
-
-impl ReadDirSimpleResult {
-    pub fn from_readdir_result(result: &ReadDirResult) -> ReadDirSimpleResult {
-        let entries: Vec<DirEntrySimple> = result
-            .entries
-            .iter()
-            .map(|e| DirEntrySimple {
-                fileid: e.fileid,
-                name: e.name.clone(),
-            })
-            .collect();
-        ReadDirSimpleResult {
-            entries,
-            end: result.end,
-        }
+impl UserContext {
+    pub fn new(uid: u32, gid: u32, gids: Vec<u32>) -> Self {
+        Self { _uid: uid, _gid: gid, _gids: gids }
     }
 }
 
-static mut GENERATION_NUMBER: u64 = 0;
-static GENERATION_NUMBER_INIT: Once = Once::new();
-
-fn get_generation_number() -> u64 {
-    unsafe {
-        GENERATION_NUMBER_INIT.call_once(|| {
-            GENERATION_NUMBER = SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_millis() as u64;
-        });
-        GENERATION_NUMBER
+impl From<&auth_unix> for UserContext {
+    fn from(auth: &auth_unix) -> Self {
+        Self { _uid: auth.uid, _gid: auth.gid, _gids: auth.gids.clone() }
     }
 }
 
-/// What capabilities are supported
-pub enum VFSCapabilities {
-    ReadOnly,
-    ReadWrite,
-}
-
-/// The basic API to implement to provide an NFS file system
-///
-/// Opaque FH
-/// ---------
-/// Files are only uniquely identified by a 64-bit file id. (basically an inode number)
-/// We automatically produce internally the opaque filehandle which is comprised of
-///  - A 64-bit generation number derived from the server startup time
-///   (i.e. so the opaque file handle expires when the NFS server restarts)
-///  - The 64-bit file id
-//
-/// readdir pagination
-/// ------------------
-/// We do not use cookie verifier. We just use the start_after.  The
-/// implementation should allow startat to start at any position. That is,
-/// the next query to readdir may be the last entry in the previous readdir
-/// response.
-//
-/// There is a wierd annoying thing about readdir that limits the number
-/// of bytes in the response (instead of the number of entries). The caller
-/// will have to truncate the readdir response / issue more calls to readdir
-/// accordingly to fill up the expected number of bytes without exceeding it.
-//
-/// Other requirements
-/// ------------------
-///  getattr needs to be fast. NFS uses that a lot
-//
-///  The 0 fileid is reserved and should not be used
-///
 #[async_trait]
-pub trait NFSFileSystem: Sync {
+pub trait NFSFileSystemExtended : Sync {
+
     /// Returns the set of capabilities supported
     fn capabilities(&self) -> VFSCapabilities;
     /// Returns the ID the of the root directory "/"
@@ -106,21 +38,24 @@ pub trait NFSFileSystem: Sync {
     /// and this should return the id of the file "dir/a.txt"
     ///
     /// This method should be fast as it is used very frequently.
-    async fn lookup(&self, dirid: fileid3, filename: &filename3) -> Result<fileid3, nfsstat3>;
+    async fn lookup(&self, dirid: fileid3, filename: &filename3, user_ctx : &UserContext, dir_attr : &mut post_op_attr, obj_attr : &mut post_op_attr) -> Result<fileid3, nfsstat3>;
 
     /// Returns the attributes of an id.
     /// This method should be fast as it is used very frequently.
-    async fn getattr(&self, id: fileid3) -> Result<fattr3, nfsstat3>;
+    async fn getattr(&self, id: fileid3, user_ctx : &UserContext) -> Result<fattr3, nfsstat3>;
 
     /// Sets the attributes of an id
     /// this should return Err(nfsstat3::NFS3ERR_ROFS) if readonly
-    async fn setattr(&self, id: fileid3, setattr: sattr3) -> Result<fattr3, nfsstat3>;
+    async fn setattr(&self, id: fileid3, setattr: sattr3, user_ctx : &UserContext) -> Result<fattr3, nfsstat3>;
+
+    /// Checks access permissions
+    async fn access(&self, id: fileid3, access : u32, user_ctx : &UserContext, obj_attr : &mut post_op_attr) -> Result<u32, nfsstat3>;
 
     /// Reads the contents of a file returning (bytes, EOF)
     /// Note that offset/count may go past the end of the file and that
     /// in that case, all bytes till the end of file are returned.
     /// EOF must be flagged if the end of the file is reached by the read.
-    async fn read(&self, id: fileid3, offset: u64, count: u32)
+    async fn read(&self, id: fileid3, offset: u64, count: u32, user_ctx : &UserContext, obj_attr : &mut post_op_attr)
         -> Result<(Vec<u8>, bool), nfsstat3>;
 
     /// Writes the contents of a file returning (bytes, EOF)
@@ -128,7 +63,7 @@ pub trait NFSFileSystem: Sync {
     /// in that case, the file is extended.
     /// If not supported due to readonly file system
     /// this should return Err(nfsstat3::NFS3ERR_ROFS)
-    async fn write(&self, id: fileid3, offset: u64, data: &[u8]) -> Result<fattr3, nfsstat3>;
+    async fn write(&self, id: fileid3, offset: u64, data: &[u8], user_ctx : &UserContext, obj_attr : &mut pre_op_attr) -> Result<fattr3, nfsstat3>;
 
     /// Creates a file with the following attributes.
     /// If not supported due to readonly file system
@@ -138,6 +73,9 @@ pub trait NFSFileSystem: Sync {
         dirid: fileid3,
         filename: &filename3,
         attr: sattr3,
+        user_ctx : &UserContext,
+        pre_dir_attr : &mut pre_op_attr,
+        post_dir_attr : &mut post_op_attr,
     ) -> Result<(fileid3, fattr3), nfsstat3>;
 
     /// Creates a file if it does not already exist
@@ -146,6 +84,9 @@ pub trait NFSFileSystem: Sync {
         &self,
         dirid: fileid3,
         filename: &filename3,
+        user_ctx : &UserContext,
+        pre_dir_attr : &mut pre_op_attr,
+        post_dir_attr : &mut post_op_attr,
     ) -> Result<fileid3, nfsstat3>;
 
     /// Makes a directory with the following attributes.
@@ -155,12 +96,15 @@ pub trait NFSFileSystem: Sync {
         &self,
         dirid: fileid3,
         dirname: &filename3,
+        user_ctx : &UserContext,
+        pre_dir_attr : &mut pre_op_attr,
+        post_dir_attr : &mut post_op_attr,
     ) -> Result<(fileid3, fattr3), nfsstat3>;
 
     /// Removes a file.
     /// If not supported due to readonly file system
     /// this should return Err(nfsstat3::NFS3ERR_ROFS)
-    async fn remove(&self, dirid: fileid3, filename: &filename3) -> Result<(), nfsstat3>;
+    async fn remove(&self, dirid: fileid3, filename: &filename3, user_ctx : &UserContext, pre_dir_attr : &mut pre_op_attr, post_dir_attr : &mut post_op_attr) -> Result<(), nfsstat3>;
 
     /// Removes a file.
     /// If not supported due to readonly file system
@@ -171,6 +115,11 @@ pub trait NFSFileSystem: Sync {
         from_filename: &filename3,
         to_dirid: fileid3,
         to_filename: &filename3,
+        user_ctx : &UserContext,
+        pre_from_dir_attr : &mut pre_op_attr,
+        pre_to_dir_attr : &mut pre_op_attr,
+        post_from_dir_attr : &mut post_op_attr,
+        post_to_dir_attr : &mut post_op_attr,
     ) -> Result<(), nfsstat3>;
 
     /// Returns the contents of a directory with pagination.
@@ -186,6 +135,7 @@ pub trait NFSFileSystem: Sync {
         dirid: fileid3,
         start_after: fileid3,
         max_entries: usize,
+        user_ctx : &UserContext,
     ) -> Result<ReadDirResult, nfsstat3>;
 
     /// Simple version of readdir.
@@ -194,9 +144,10 @@ pub trait NFSFileSystem: Sync {
         &self,
         dirid: fileid3,
         count: usize,
+        user_ctx : &UserContext,
     ) -> Result<ReadDirSimpleResult, nfsstat3> {
         Ok(ReadDirSimpleResult::from_readdir_result(
-            &self.readdir(dirid, 0, count).await?,
+            &self.readdir(dirid, 0, count, user_ctx).await?,
         ))
     }
 
@@ -209,18 +160,22 @@ pub trait NFSFileSystem: Sync {
         linkname: &filename3,
         symlink: &nfspath3,
         attr: &sattr3,
+        user_ctx : &UserContext,
+        pre_obj_attr : &mut pre_op_attr,
+        post_obj_attr : &mut post_op_attr,
     ) -> Result<(fileid3, fattr3), nfsstat3>;
 
     /// Reads a symlink
-    async fn readlink(&self, id: fileid3) -> Result<nfspath3, nfsstat3>;
+    async fn readlink(&self, id: fileid3, user_ctx: &UserContext, symlink_attr : &mut post_op_attr) -> Result<nfspath3, nfsstat3>;
 
     /// Get static file system Information
     async fn fsinfo(
         &self,
         root_fileid: fileid3,
+        user_ctx : &UserContext,
     ) -> Result<fsinfo3, nfsstat3> {
 
-        let dir_attr: nfs::post_op_attr = match self.getattr(root_fileid).await {
+        let dir_attr: nfs::post_op_attr = match self.getattr(root_fileid, user_ctx).await {
             Ok(v) => nfs::post_op_attr::attributes(v),
             Err(_) => nfs::post_op_attr::Void,
         };
@@ -245,43 +200,14 @@ pub trait NFSFileSystem: Sync {
     }
 
     /// Converts the fileid to an opaque NFS file handle. Optional.
-    fn id_to_fh(&self, id: fileid3) -> nfs_fh3 {
-        let gennum = get_generation_number();
-        let mut ret: Vec<u8> = Vec::new();
-        ret.extend_from_slice(&gennum.to_le_bytes());
-        ret.extend_from_slice(&id.to_le_bytes());
-        nfs_fh3 { data: ret }
-    }
+    fn id_to_fh(&self, id: fileid3) -> nfs_fh3;
+
     /// Converts an opaque NFS file handle to a fileid.  Optional.
-    fn fh_to_id(&self, id: &nfs_fh3) -> Result<fileid3, nfsstat3> {
-        if id.data.len() != 16 {
-            return Err(nfsstat3::NFS3ERR_BADHANDLE);
-        }
-        let gen = u64::from_le_bytes(id.data[0..8].try_into().unwrap());
-        let id = u64::from_le_bytes(id.data[8..16].try_into().unwrap());
-        let gennum = get_generation_number();
-        match gen.cmp(&gennum) {
-            Ordering::Less => Err(nfsstat3::NFS3ERR_STALE),
-            Ordering::Greater => Err(nfsstat3::NFS3ERR_BADHANDLE),
-            Ordering::Equal => Ok(id),
-        }
-    }
+    fn fh_to_id(&self, id: &nfs_fh3) -> Result<fileid3, nfsstat3>;
+
     /// Converts a complete path to a fileid.  Optional.
     /// The default implementation walks the directory structure with lookup()
-    async fn path_to_id(&self, path: &[u8]) -> Result<fileid3, nfsstat3> {
-        let splits = path.split(|&r| r == b'/');
-        let mut fid = self.root_dir();
-        for component in splits {
-            if component.is_empty() {
-                continue;
-            }
-            fid = self.lookup(fid, &component.into()).await?;
-        }
-        Ok(fid)
-    }
+    async fn path_to_id(&self, path: &[u8]) -> Result<fileid3, nfsstat3>;
 
-    fn serverid(&self) -> cookieverf3 {
-        let gennum = get_generation_number();
-        gennum.to_le_bytes()
-    }
+    fn serverid(&self) -> cookieverf3;
 }

--- a/src/vfsextimpl.rs
+++ b/src/vfsextimpl.rs
@@ -1,0 +1,419 @@
+use crate::nfs::*;
+use crate::vfsext::NFSFileSystemExtended;
+use crate::vfsext::UserContext;
+use crate::vfs::*;
+use async_trait::async_trait;
+use std::sync::Arc;
+
+pub struct DefaultNFSFileSystemExtended {
+   pub vfs: Arc<dyn NFSFileSystem + Send + Sync>,
+}
+
+#[async_trait]
+impl NFSFileSystemExtended for DefaultNFSFileSystemExtended {
+
+    /// Returns the set of capabilities supported
+    fn capabilities(&self) -> VFSCapabilities {
+        self.vfs.capabilities()
+    }
+
+
+    /// Returns the ID the of the root directory "/"
+    fn root_dir(&self) -> fileid3 {
+        self.vfs.root_dir()
+    }
+
+    /// Look up the id of a path in a directory
+    ///
+    /// i.e. given a directory dir/ containing a file a.txt
+    /// this may call lookup(id_of("dir/"), "a.txt")
+    /// and this should return the id of the file "dir/a.txt"
+    ///
+    /// This method should be fast as it is used very frequently.
+    async fn lookup(&self, dirid: fileid3, filename: &filename3, _user_ctx : &UserContext, dir_attr : &mut post_op_attr, obj_attr : &mut post_op_attr) -> Result<fileid3, nfsstat3> {
+
+        *dir_attr = match self.vfs.getattr(dirid).await {
+            Ok(v) => post_op_attr::attributes(v),
+            Err(_) => post_op_attr::Void,
+        };
+        let result = self.vfs.lookup(dirid, filename).await;
+        match result {
+            Ok(fid) => {
+                *obj_attr = match self.vfs.getattr(fid).await {
+                    Ok(v) => post_op_attr::attributes(v),
+                    Err(_) => post_op_attr::Void,
+                };
+            }
+            Err(_) => {
+            }
+        }
+        result
+    }
+
+    /// Returns the attributes of an id.
+    /// This method should be fast as it is used very frequently.
+    async fn getattr(&self, id: fileid3, _user_ctx : &UserContext) -> Result<fattr3, nfsstat3> {
+        self.vfs.getattr(id).await
+    }
+
+    /// Sets the attributes of an id
+    /// this should return Err(nfsstat3::NFS3ERR_ROFS) if readonly
+    async fn setattr(&self, id: fileid3, setattr: sattr3, _user_ctx : &UserContext) -> Result<fattr3, nfsstat3> {
+        self.vfs.setattr(id, setattr).await
+    }
+
+    async fn access(&self, id: fileid3, access : u32, _user_ctx : &UserContext, obj_attr : &mut post_op_attr) -> Result<u32, nfsstat3> {
+        *obj_attr = match self.vfs.getattr(id).await {
+            Ok(v) => post_op_attr::attributes(v),
+            Err(stat) =>  {
+                return Err(stat)
+            }
+        };
+
+        let mut new_access : u32 = access;
+        if !matches!(self.vfs.capabilities(), VFSCapabilities::ReadWrite) {
+            new_access &= ACCESS3_READ | ACCESS3_LOOKUP;
+        }
+
+        Ok(new_access)
+    }
+
+
+    /// Reads the contents of a file returning (bytes, EOF)
+    /// Note that offset/count may go past the end of the file and that
+    /// in that case, all bytes till the end of file are returned.
+    /// EOF must be flagged if the end of the file is reached by the read.
+    async fn read(&self, id: fileid3, offset: u64, count: u32, _user_ctx : &UserContext, obj_attr : &mut post_op_attr) -> Result<(Vec<u8>, bool), nfsstat3> {
+        *obj_attr = match self.vfs.getattr(id).await {
+            Ok(v) => post_op_attr::attributes(v),
+            Err(_) => post_op_attr::Void,
+        };
+        self.vfs.read(id, offset, count).await
+    }
+
+    /// Writes the contents of a file returning (bytes, EOF)
+    /// Note that offset/count may go past the end of the file and that
+    /// in that case, the file is extended.
+    /// If not supported due to readonly file system
+    /// this should return Err(nfsstat3::NFS3ERR_ROFS)
+    async fn write(&self, id: fileid3, offset: u64, data: &[u8], _user_ctx : &UserContext, obj_attr : &mut pre_op_attr) -> Result<fattr3, nfsstat3> {
+        *obj_attr = match self.vfs.getattr(id).await {
+            Ok(v) => {
+                let wccattr = wcc_attr {
+                    size: v.size,
+                    mtime: v.mtime,
+                    ctime: v.ctime,
+                };
+                pre_op_attr::attributes(wccattr)
+            }
+            Err(_) => pre_op_attr::Void,
+        };
+
+        self.vfs.write(id, offset, data).await
+    }
+
+    /// Creates a file with the following attributes.
+    /// If not supported due to readonly file system
+    /// this should return Err(nfsstat3::NFS3ERR_ROFS)
+    async fn create(
+        &self,
+        dirid: fileid3,
+        filename: &filename3,
+        attr: sattr3,
+        _user_ctx : &UserContext,
+        pre_dir_attr : &mut pre_op_attr,
+        post_dir_attr : &mut post_op_attr,
+    ) -> Result<(fileid3, fattr3), nfsstat3> {
+        *pre_dir_attr = match self.vfs.getattr(dirid).await {
+            Ok(v) => {
+                let wccattr = wcc_attr {
+                    size: v.size,
+                    mtime: v.mtime,
+                    ctime: v.ctime,
+                };
+                pre_op_attr::attributes(wccattr)
+            }
+            Err(_) => pre_op_attr::Void,
+        };
+
+        let result = self.vfs.create(dirid, filename, attr).await;
+
+        // Re-read dir attributes for post op attr
+        *post_dir_attr = match self.vfs.getattr(dirid).await {
+            Ok(v) => post_op_attr::attributes(v),
+            Err(_) => post_op_attr::Void,
+        };
+
+        result
+    }
+
+    /// Creates a file if it does not already exist
+    /// this should return Err(nfsstat3::NFS3ERR_ROFS)
+    async fn create_exclusive(
+        &self,
+        dirid: fileid3,
+        filename: &filename3,
+        _user_ctx : &UserContext,
+        pre_dir_attr : &mut pre_op_attr,
+        post_dir_attr : &mut post_op_attr,
+    ) -> Result<fileid3, nfsstat3> {
+        *pre_dir_attr = match self.vfs.getattr(dirid).await {
+            Ok(v) => {
+                let wccattr = wcc_attr {
+                    size: v.size,
+                    mtime: v.mtime,
+                    ctime: v.ctime,
+                };
+                pre_op_attr::attributes(wccattr)
+            }
+            Err(stat) =>
+                return Err(stat)
+        };
+
+        let result = self.vfs.create_exclusive(dirid, filename).await;
+
+        // Re-read dir attributes for post op attr
+        *post_dir_attr = match self.vfs.getattr(dirid).await {
+            Ok(v) => post_op_attr::attributes(v),
+            Err(_) => post_op_attr::Void,
+        };
+
+        result
+    }
+
+    /// Makes a directory with the following attributes.
+    /// If not supported dur to readonly file system
+    /// this should return Err(nfsstat3::NFS3ERR_ROFS)
+    async fn mkdir(
+        &self,
+        dirid: fileid3,
+        dirname: &filename3,
+        _user_ctx : &UserContext,
+        pre_dir_attr : &mut pre_op_attr,
+        post_dir_attr : &mut post_op_attr,
+    ) -> Result<(fileid3, fattr3), nfsstat3> {
+        // get the object attributes before the write
+        *pre_dir_attr = match self.vfs.getattr(dirid).await {
+            Ok(v) => {
+                let wccattr = wcc_attr {
+                    size: v.size,
+                    mtime: v.mtime,
+                    ctime: v.ctime,
+                };
+                pre_op_attr::attributes(wccattr)
+            }
+            Err(stat) => {
+                return Err(stat)
+            }
+        };
+
+        let result = self.vfs.mkdir(dirid, dirname).await;
+
+        // Re-read dir attributes for post op attr
+        *post_dir_attr = match self.vfs.getattr(dirid).await {
+            Ok(v) => post_op_attr::attributes(v),
+            Err(_) => post_op_attr::Void,
+        };
+
+        result
+    }
+
+    /// Removes a file.
+    /// If not supported due to readonly file system
+    /// this should return Err(nfsstat3::NFS3ERR_ROFS)
+    async fn remove(&self, dirid: fileid3, filename: &filename3, _user_ctx : &UserContext, pre_dir_attr : &mut pre_op_attr, post_dir_attr : &mut post_op_attr) -> Result<(), nfsstat3> {
+        // get the object attributes before the write
+        *pre_dir_attr = match self.vfs.getattr(dirid).await {
+            Ok(v) => {
+                let wccattr = wcc_attr {
+                    size: v.size,
+                    mtime: v.mtime,
+                    ctime: v.ctime,
+                };
+                pre_op_attr::attributes(wccattr)
+            }
+            Err(stat) => {
+                return Err(stat)
+            }
+        };
+
+        let result = self.vfs.remove(dirid, filename).await;
+
+        // Re-read dir attributes for post op attr
+        *post_dir_attr = match self.vfs.getattr(dirid).await {
+            Ok(v) => post_op_attr::attributes(v),
+            Err(_) => post_op_attr::Void,
+        };
+
+        result
+    }
+
+    /// Removes a file.
+    /// If not supported due to readonly file system
+    /// this should return Err(nfsstat3::NFS3ERR_ROFS)
+    async fn rename(
+        &self,
+        from_dirid: fileid3,
+        from_filename: &filename3,
+        to_dirid: fileid3,
+        to_filename: &filename3,
+       _user_ctx : &UserContext,
+        pre_from_dir_attr : &mut pre_op_attr,
+        pre_to_dir_attr : &mut pre_op_attr,
+        post_from_dir_attr : &mut post_op_attr,
+        post_to_dir_attr : &mut post_op_attr,
+    ) -> Result<(), nfsstat3> {
+        // get the object attributes before the write
+        *pre_from_dir_attr = match self.vfs.getattr(from_dirid).await {
+            Ok(v) => {
+                let wccattr = wcc_attr {
+                    size: v.size,
+                    mtime: v.mtime,
+                    ctime: v.ctime,
+                };
+                pre_op_attr::attributes(wccattr)
+            }
+            Err(stat) => {
+                return Err(stat)
+            }
+        };
+
+        // get the object attributes before the write
+        *pre_to_dir_attr = match self.vfs.getattr(to_dirid).await {
+            Ok(v) => {
+                let wccattr = wcc_attr {
+                    size: v.size,
+                    mtime: v.mtime,
+                    ctime: v.ctime,
+                };
+                pre_op_attr::attributes(wccattr)
+            }
+            Err(stat) => {
+                return Err(stat)
+            }
+        };
+
+        let result = self.vfs.rename(from_dirid, from_filename, to_dirid, to_filename).await;
+
+        // Re-read dir attributes for post op attr
+        *post_from_dir_attr = match self.vfs.getattr(from_dirid).await {
+            Ok(v) => post_op_attr::attributes(v),
+            Err(_) => post_op_attr::Void,
+        };
+        *post_to_dir_attr = match self.vfs.getattr(to_dirid,).await {
+            Ok(v) => post_op_attr::attributes(v),
+            Err(_) => post_op_attr::Void,
+        };
+
+        result
+    }
+
+    /// Returns the contents of a directory with pagination.
+    /// Directory listing should be deterministic.
+    /// Up to max_entries may be returned, and start_after is used
+    /// to determine where to start returning entries from.
+    ///
+    /// For instance if the directory has entry with ids [1,6,2,11,8,9]
+    /// and start_after=6, readdir should returning 2,11,8,...
+    //
+    async fn readdir(
+        &self,
+        dirid: fileid3,
+        start_after: fileid3,
+        max_entries: usize,
+        _user_ctx : &UserContext,
+    ) -> Result<ReadDirResult, nfsstat3> {
+        self.vfs.readdir(dirid, start_after, max_entries).await
+    }
+
+    /// Simple version of readdir.
+    /// Only need to return filename and id
+    async fn readdir_simple(
+        &self,
+        dirid: fileid3,
+        count: usize,
+        user_ctx : &UserContext,
+    ) -> Result<ReadDirSimpleResult, nfsstat3> {
+        Ok(ReadDirSimpleResult::from_readdir_result(
+            &self.readdir(dirid, 0, count, user_ctx).await?,
+        ))
+    }
+
+    /// Makes a symlink with the following attributes.
+    /// If not supported due to readonly file system
+    /// this should return Err(nfsstat3::NFS3ERR_ROFS)
+    async fn symlink(
+        &self,
+        dirid: fileid3,
+        linkname: &filename3,
+        symlink: &nfspath3,
+        attr: &sattr3,
+        _user_ctx : &UserContext,
+        pre_obj_attr : &mut pre_op_attr,
+        post_obj_attr : &mut post_op_attr,
+    ) -> Result<(fileid3, fattr3), nfsstat3> {
+        // get the object attributes before
+        *pre_obj_attr = match self.vfs.getattr(dirid).await {
+            Ok(v) => {
+                let wccattr = wcc_attr {
+                    size: v.size,
+                    mtime: v.mtime,
+                    ctime: v.ctime,
+                };
+                pre_op_attr::attributes(wccattr)
+            }
+            Err(stat) => {
+                return Err(stat)
+            }
+        };
+
+        let result = self.vfs.symlink(dirid, linkname, symlink, attr).await;
+
+        // Re-read dir attributes for post op attr
+        *post_obj_attr = match self.vfs.getattr(dirid).await {
+            Ok(v) => post_op_attr::attributes(v),
+            Err(_) => post_op_attr::Void,
+        };
+
+        result
+    }
+
+    /// Reads a symlink
+    async fn readlink(&self, id: fileid3, _user_ctx : &UserContext, symlink_attr : &mut post_op_attr) -> Result<nfspath3, nfsstat3> {
+        *symlink_attr = match self.vfs.getattr(id).await {
+            Ok(v) => post_op_attr::attributes(v),
+            Err(stat) => {
+                return Err(stat)
+            }
+        };
+        self.vfs.readlink(id).await
+    }
+
+    /// Get static file system Information
+    async fn fsinfo(
+        &self,
+        root_fileid: fileid3,
+        _user_ctx: &UserContext,
+    ) -> Result<fsinfo3, nfsstat3> {
+        self.vfs.fsinfo(root_fileid).await
+    }
+
+    /// Converts the fileid to an opaque NFS file handle. Optional.
+    fn id_to_fh(&self, id: fileid3) -> nfs_fh3 {
+        self.vfs.id_to_fh(id)
+    }
+
+    /// Converts an opaque NFS file handle to a fileid.  Optional.
+    fn fh_to_id(&self, id: &nfs_fh3) -> Result<fileid3, nfsstat3> {
+        self.vfs.fh_to_id(id)
+    }
+    /// Converts a complete path to a fileid.  Optional.
+    /// The default implementation walks the directory structure with lookup()
+    async fn path_to_id(&self, path: &[u8]) -> Result<fileid3, nfsstat3> {
+        self.vfs.path_to_id(path).await
+    }
+
+    fn serverid(&self) -> cookieverf3 {
+        self.vfs.serverid()
+    }
+}


### PR DESCRIPTION
Introduce extended NFS File System interface. 
The functions in the extended file system interface get additional context information for the call,
that could be evaluated in a file system backend backend.

The original NFS File System  interface is not changed, but it is called from the default implementation.
This ensures downward compatibility. Implementations still could use the original interface 
which is easier to use, if the extended functionality is not required.