### PR TITLE
Add support for detecting and handling retransmissions

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -2,6 +2,8 @@ use crate::vfs::NFSFileSystem;
 use std::fmt;
 use std::sync::Arc;
 use tokio::sync::mpsc;
+use crate::transaction_tracker::TransactionTracker;
+
 #[derive(Clone)]
 pub struct RPCContext {
     pub local_port: u16,
@@ -9,6 +11,7 @@ pub struct RPCContext {
     pub auth: crate::rpc::auth_unix,
     pub vfs: Arc<dyn NFSFileSystem + Send + Sync>,
     pub mount_signal: Option<mpsc::Sender<bool>>,
+    pub transaction_tracker: Arc<TransactionTracker>,
 }
 
 impl fmt::Debug for RPCContext {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,3 +20,4 @@ pub mod fs_util;
 
 pub mod tcp;
 pub mod vfs;
+mod transaction_tracker;

--- a/src/transaction_tracker.rs
+++ b/src/transaction_tracker.rs
@@ -1,0 +1,57 @@
+use std::collections::{HashMap};
+use std::sync::Mutex;
+use std::time::{Duration, SystemTime};
+
+/// `TransactionTracker` tracks the state of transactions to detect retransmissions.
+pub struct TransactionTracker {
+    retention_period: Duration,
+    transactions: Mutex<HashMap<(u32, String), TransactionState>>,
+}
+
+impl TransactionTracker {
+    pub fn new(retention_period: Duration) -> Self {
+        Self {
+            retention_period,
+            transactions: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Checks if the transaction is a retransmission.
+    /// If it's a new transaction, it is marked as `InProgress`.
+    ///
+    /// Returns `true` if the transaction is a retransmission, `false` otherwise.
+    pub fn is_retransmission(&self, xid: u32, client_addr: &str) -> bool {
+        let key = (xid, client_addr.to_string());
+        let mut xids = self.transactions.lock().expect("unable to unlock transactions mutex");
+        housekeeping(&mut xids, self.retention_period);
+        if xids.contains_key(&key) {
+            true
+        } else {
+            xids.insert(key, TransactionState::InProgress);
+            false
+        }
+    }
+
+    /// Marks the transaction as processed.
+    pub fn mark_processed(&self, xid: u32, client_addr: &str) {
+        let key = (xid, client_addr.to_string());
+        let completed = SystemTime::now();
+        let mut transactions = self.transactions.lock().expect("unable to unlock transactions mutex");
+        if let Some(tx) = transactions.get_mut(&key) {
+            *tx = TransactionState::Completed(completed);
+        }
+    }
+}
+
+fn housekeeping(transactions: &mut HashMap<(u32, String), TransactionState>, max_age: Duration) {
+    let mut cutoff = SystemTime::now() - max_age;
+    transactions.retain(|_, v| match v {
+        TransactionState::InProgress => true,
+        TransactionState::Completed(completed) => completed >= &mut cutoff,
+    });
+}
+
+pub enum TransactionState {
+    InProgress,
+    Completed(SystemTime),
+}


### PR DESCRIPTION
During testing, I noticed that the Windows client sometimes retransmits messages if the server response takes longer. This caused issues with my server, which operates on remote data.

Retransmissions don't make sense with TCP, but it looks like the Windows client uses the same code path for both UDP and TCP.

To address this, I added a `TransactionTracker` to keep track of current and recent transactions using the `xid` and `client_addr`. If a retransmission is detected, the message is quietly dropped.

This implementation is simple and doesn't introduce any new dependencies. It uses a `Mutex` and calls `to_string()`, so there's a small overhead. Currently, housekeeping happens on every call to `is_retransmission`. If preferred, I can add a background task to handle this periodically instead.