### PR TITLE
Add configurable NFS export name to improve compatibility

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -9,6 +9,7 @@ pub struct RPCContext {
     pub auth: crate::rpc::auth_unix,
     pub vfs: Arc<dyn NFSFileSystem + Send + Sync>,
     pub mount_signal: Option<mpsc::Sender<bool>>,
+    pub export_name: Arc<String>,
 }
 
 impl fmt::Debug for RPCContext {


### PR DESCRIPTION
## Problem

Currently, there are some issues with the Windows NFS client:

1. **Rename does not work:** Renaming files and folders results in an `Invalid Device` error (see https://github.com/xetdata/nfsserve/issues/24). This error occurs entirely on the client; no rename request is sent to the server.

2. **Mount Path Sensitivity:** Two leading slashes after the server address are required for proper mounting. Using a single slash allows mounting but results in an `Access Denied` error when accessing the drive. Example:
```
mount -o anon -o nolock \\127.0.0.1\\ X:  # Works
mount -o anon -o nolock \\127.0.0.1\ X:   # Appears to work, but fails later with 'Access Denied' error
```

## Cause

Weirdly, these issues are causes by the NFS export path being set to `/`. For whatever legacy reasons this causes the Windows client to misbehave. The Windows client really wants the export path to have a name, not just `/`.

Within `nfsserve` the export path is currently hardcoded to `/`. Clearly, there is nothing wrong with that and setting the export path to `/` is perfectly legitimate and sensible. However, it also means that there is no way to fix the above-mentioned issues when having to work with Windows clients.

## Solution

This PR allows setting a custom export name to work around these *eccentricities*.

### How to use

Call `with_export_name` on `NFSTcpListener` before `handle_forever`:

```rust
let listener = NFSTcpListener::bind(&format!("127.0.0.1:{HOSTPORT}"), fs)
        .await
        .unwrap();
listener.with_export_name("foo");
listener.handle_forever().await.unwrap();   
```

Then, mount the export like this:


```
mount -o anon -o nolock \\127.0.0.1\foo X:
```

With this change, the Windows client should behave more as expected.