### PR TITLE
Update package metadata for Hugging Face ownership

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Install Rust 1.90
-        uses: dtolnay/rust-toolchain@1.90.0
+        uses: dtolnay/rust-toolchain@1.90
         with:
           components: clippy
       - name: Lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           components: rustfmt
       - name: Format
         run: |
-          cargo fmt --manifest-path ./Cargo.toml --all -- --check
+          cargo +nightly fmt --manifest-path ./Cargo.toml --all -- --check
 
   build_and_test-linux:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "nfsserve"
-version = "0.10.2"
+version = "0.11.0"
 edition = "2021"
-authors = ["Yucheng Low <ylow@xethub.com>"]
+authors = ["Rajat Arya <rajat@huggingface.co>", "Assaf Vayner <assaf@huggingface.co>"]
 description = "A Rust NFS Server implementation"
-homepage = "https://github.com/xetdata/nfsserve"
-repository = "https://github.com/xetdata/nfsserve"
+homepage = "https://github.com/huggingface/nfsserve"
+repository = "https://github.com/huggingface/nfsserve"
 readme = "README.md"
 keywords = ["nfs"]
 license = "BSD-3-Clause"

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 BSD 3-Clause License
 
 Copyright (c) 2023, XetData
+Copyright (c) 2025, Hugging Face
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/README.md
+++ b/README.md
@@ -20,12 +20,8 @@ a lot of the work myself.
 So, this is a FUSE-like user-mode filesystem API that basically works by 
 creating a localhost NFSv3 server you can mount.
 
-This is used in [pyxet](https://github.com/xetdata/pyxet) and 
-[xet-core](https://github.com/xetdata/xet-core/) to provide the `xet mount`
-functionality that allows you to mount multi-TB [Xethub](https://about.xethub.com) repository
-anywhere.
-
-This is a blogpost explaining our rationale: https://about.xethub.com/blog/nfs-fuse-why-we-built-nfs-server-rust
+This is used in [xet-core](https://github.com/huggingface/xet-core/) to provide the `xet mount`
+functionality.
 
 Run the Demo
 ============
@@ -77,7 +73,7 @@ TODO and Seeking Contributors
  but prints a lot of garbage due to various unimplemented APIs. Windows 11
  somehow tries to poll with very old NFS protocols constantly.
  - Many many perf optimizations. 
- - Maybe pull in the mount command from [xet-core](https://github.com/xetdata/xet-core/blob/main/rust/gitxetcore/src/xetmnt/mod.rs)
+ - Maybe pull in the mount command from [xet-core](https://github.com/huggingface/xet-core/blob/main/rust/gitxetcore/src/xetmnt/mod.rs)
  so the user does not need to remember the `-o` incantations above.
  - Maybe make an SMB3 implementation so we can work on Windows Home edition
  - NFSv4 has some write performance optimizations that would be quite nice.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ a lot of the work myself.
 So, this is a FUSE-like user-mode filesystem API that basically works by 
 creating a localhost NFSv3 server you can mount.
 
-This is used in [xet-core](https://github.com/huggingface/xet-core/) to provide the `xet mount`
+This is used in [hf-mount](https://github.com/huggingface/hf-mount) to provide the `hf-mount`
 functionality.
 
 Run the Demo

--- a/src/xdr.rs
+++ b/src/xdr.rs
@@ -229,4 +229,6 @@ macro_rules! xdr_bool_union {
     };
 }
 
-pub(crate) use {xdr_bool_union, xdr_enum_serde, xdr_struct};
+pub(crate) use xdr_bool_union;
+pub(crate) use xdr_enum_serde;
+pub(crate) use xdr_struct;


### PR DESCRIPTION
## Summary
- Bump version from 0.10.2 to 0.11.0
- Update authors to Rajat Arya and Assaf Vayner (Hugging Face)
- Point `homepage` and `repository` URLs to `huggingface/nfsserve`
- Add Hugging Face copyright to LICENSE (preserving original XetData copyright)
- Update README: remove pyxet link and xethub blog post, update xet-core links to `huggingface/xet-core`

## Test plan
- [ ] Verify `cargo build` succeeds
- [ ] Verify crate metadata looks correct with `cargo package --list`