### PR TITLE
docs(vfs): fix rename trait method docstring

### DIFF
--- a/src/vfs.rs
+++ b/src/vfs.rs
@@ -146,7 +146,7 @@ pub trait NFSFileSystem: Sync {
     /// this should return Err(nfsstat3::NFS3ERR_ROFS)
     async fn remove(&self, dirid: fileid3, filename: &filename3) -> Result<(), nfsstat3>;
 
-    /// Removes a file.
+    /// Renames a file.
     /// If not supported due to readonly file system
     /// this should return Err(nfsstat3::NFS3ERR_ROFS)
     async fn rename(


### PR DESCRIPTION
Closes #39.

`src/vfs.rs` had a copy-paste docstring on the `rename` trait method:

```rust
/// Removes a file.
/// If not supported due to readonly file system
/// this should return Err(nfsstat3::NFS3ERR_ROFS)
async fn rename(...)
```

Replace `Removes a file.` with `Renames a file.` so the docstring matches the actual method.

Verified against main at fetch time, `cargo check` clean, `cargo test --lib` passes (0/0 tests — project has no unit tests in the lib target).