### PR TITLE
Make the connection handler transport-generic (serve over TLS / any AsyncRead+AsyncWrite)

### DIFF
--- a/src/rpcwire.rs
+++ b/src/rpcwire.rs
@@ -105,7 +105,7 @@ async fn read_fragment(socket: &mut DuplexStream, append_to: &mut Vec<u8>) -> Re
     Ok(is_last)
 }
 
-pub async fn write_fragment(socket: &mut tokio::net::TcpStream, buf: &[u8]) -> Result<(), anyhow::Error> {
+pub async fn write_fragment<W: tokio::io::AsyncWrite + Unpin>(socket: &mut W, buf: &[u8]) -> Result<(), anyhow::Error> {
     // TODO: split into many fragments
     assert!(buf.len() < (1 << 31));
     // set the last flag

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -32,7 +32,6 @@ pub fn generate_host_ip(hostnum: u16) -> String {
 /// processes an established socket
 async fn process_socket(mut socket: tokio::net::TcpStream, context: RPCContext) -> Result<(), anyhow::Error> {
     let (mut message_handler, mut socksend, mut msgrecvchan) = SocketMessageHandler::new(&context);
-    let _ = socket.set_nodelay(true);
 
     tokio::spawn(async move {
         loop {
@@ -207,6 +206,9 @@ impl<T: NFSFileSystem + Send + Sync + 'static> NFSTcp for NFSTcpListener<T> {
             };
             info!("Accepting connection from {}", context.client_addr);
             debug!("Accepting socket {:?} {:?}", socket, context);
+            // `set_nodelay` is `TcpStream`-specific, so it lives here in the
+            // listener rather than in `process_socket`.
+            let _ = socket.set_nodelay(true);
             tokio::spawn(async move {
                 let _ = process_socket(socket, context).await;
             });

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 use anyhow;
 use async_trait::async_trait;
-use tokio::io::AsyncWriteExt;
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use tokio::net::TcpListener;
 use tokio::sync::mpsc;
 use tracing::{debug, error, info};
@@ -29,9 +29,23 @@ pub fn generate_host_ip(hostnum: u16) -> String {
     format!("127.88.{}.{}", ((hostnum >> 8) & 0xFF) as u8, (hostnum & 0xFF) as u8)
 }
 
-/// processes an established socket
-async fn process_socket(mut socket: tokio::net::TcpStream, context: RPCContext) -> Result<(), anyhow::Error> {
+/// Serve a single established connection. Generic over the stream so callers can
+/// pass a plaintext `TcpStream` or an already-handshaked TLS stream
+/// (e.g. `tokio_rustls::server::TlsStream`) — `nfsserve` stays TLS-agnostic.
+///
+/// `NFSTcpListener` uses this internally for plaintext TCP. To terminate TLS in
+/// process, hand it an already-handshaked stream:
+///
+/// ```ignore
+/// // `tls` is a `tokio_rustls::server::TlsStream<TcpStream>` after `acceptor.accept(tcp).await?`.
+/// nfsserve::tcp::process_socket(tls, context).await?;
+/// ```
+pub async fn process_socket<S>(socket: S, context: RPCContext) -> Result<(), anyhow::Error>
+where
+    S: AsyncRead + AsyncWrite + Send + 'static,
+{
     let (mut message_handler, mut socksend, mut msgrecvchan) = SocketMessageHandler::new(&context);
+    let (mut reader, mut writer) = tokio::io::split(socket);
 
     tokio::spawn(async move {
         loop {
@@ -41,27 +55,18 @@ async fn process_socket(mut socket: tokio::net::TcpStream, context: RPCContext) 
             }
         }
     });
+    let mut buf = vec![0u8; 128000];
     loop {
         tokio::select! {
-            _ = socket.readable() => {
-                let mut buf = [0; 128000];
-
-                match socket.try_read(&mut buf) {
-                    Ok(0) => {
-                        return Ok(());
-                    }
-                    Ok(n) => {
-                        let _ = socksend.write_all(&buf[..n]).await;
-                    }
-                    Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
-                        continue;
-                    }
+            res = reader.read(&mut buf) => {
+                match res {
+                    Ok(0) => return Ok(()),
+                    Ok(n) => { let _ = socksend.write_all(&buf[..n]).await; }
                     Err(e) => {
                         debug!("Message handling closed : {:?}", e);
                         return Err(e.into());
                     }
                 }
-
             },
             reply = msgrecvchan.recv() => {
                 match reply {
@@ -70,8 +75,10 @@ async fn process_socket(mut socket: tokio::net::TcpStream, context: RPCContext) 
                         return Err(e);
                     }
                     Some(Ok(msg)) => {
-                        if let Err(e) = write_fragment(&mut socket, &msg).await {
+                        if let Err(e) = write_fragment(&mut writer, &msg).await {
                             error!("Write error {:?}", e);
+                        } else if let Err(e) = writer.flush().await {
+                            error!("Flush error {:?}", e);
                         }
                     }
                     None => {
@@ -195,6 +202,7 @@ impl<T: NFSFileSystem + Send + Sync + 'static> NFSTcp for NFSTcpListener<T> {
     async fn handle_forever(&self) -> io::Result<()> {
         loop {
             let (socket, _) = self.listener.accept().await?;
+            let _ = socket.set_nodelay(true);
             let context = RPCContext {
                 local_port: self.port,
                 client_addr: socket.peer_addr().unwrap().to_string(),
@@ -206,12 +214,155 @@ impl<T: NFSFileSystem + Send + Sync + 'static> NFSTcp for NFSTcpListener<T> {
             };
             info!("Accepting connection from {}", context.client_addr);
             debug!("Accepting socket {:?} {:?}", socket, context);
-            // `set_nodelay` is `TcpStream`-specific, so it lives here in the
-            // listener rather than in `process_socket`.
-            let _ = socket.set_nodelay(true);
             tokio::spawn(async move {
                 let _ = process_socket(socket, context).await;
             });
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+
+    use async_trait::async_trait;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    use super::*;
+    use crate::nfs::{fattr3, fileid3, filename3, nfspath3, nfsstat3, sattr3};
+    use crate::rpc::{auth_unix, call_body, opaque_auth, reply_body, rpc_body, rpc_msg};
+    use crate::vfs::{NFSFileSystem, ReadDirResult, VFSCapabilities};
+    use crate::xdr::XDR;
+
+    /// A do-nothing filesystem: enough to build an `RPCContext`. The NULL
+    /// procedure exercised below never touches the VFS, so every data method
+    /// just reports "not supported".
+    struct NullFS;
+
+    #[async_trait]
+    impl NFSFileSystem for NullFS {
+        fn capabilities(&self) -> VFSCapabilities {
+            VFSCapabilities::ReadOnly
+        }
+        fn root_dir(&self) -> fileid3 {
+            1
+        }
+        async fn lookup(&self, _: fileid3, _: &filename3) -> Result<fileid3, nfsstat3> {
+            Err(nfsstat3::NFS3ERR_NOTSUPP)
+        }
+        async fn getattr(&self, _: fileid3) -> Result<fattr3, nfsstat3> {
+            Err(nfsstat3::NFS3ERR_NOTSUPP)
+        }
+        async fn setattr(&self, _: fileid3, _: sattr3) -> Result<fattr3, nfsstat3> {
+            Err(nfsstat3::NFS3ERR_NOTSUPP)
+        }
+        async fn read(&self, _: fileid3, _: u64, _: u32) -> Result<(Vec<u8>, bool), nfsstat3> {
+            Err(nfsstat3::NFS3ERR_NOTSUPP)
+        }
+        async fn write(&self, _: fileid3, _: u64, _: &[u8]) -> Result<fattr3, nfsstat3> {
+            Err(nfsstat3::NFS3ERR_NOTSUPP)
+        }
+        async fn create(&self, _: fileid3, _: &filename3, _: sattr3) -> Result<(fileid3, fattr3), nfsstat3> {
+            Err(nfsstat3::NFS3ERR_NOTSUPP)
+        }
+        async fn create_exclusive(&self, _: fileid3, _: &filename3) -> Result<fileid3, nfsstat3> {
+            Err(nfsstat3::NFS3ERR_NOTSUPP)
+        }
+        async fn mkdir(&self, _: fileid3, _: &filename3) -> Result<(fileid3, fattr3), nfsstat3> {
+            Err(nfsstat3::NFS3ERR_NOTSUPP)
+        }
+        async fn remove(&self, _: fileid3, _: &filename3) -> Result<(), nfsstat3> {
+            Err(nfsstat3::NFS3ERR_NOTSUPP)
+        }
+        async fn rename(&self, _: fileid3, _: &filename3, _: fileid3, _: &filename3) -> Result<(), nfsstat3> {
+            Err(nfsstat3::NFS3ERR_NOTSUPP)
+        }
+        async fn readdir(&self, _: fileid3, _: fileid3, _: usize) -> Result<ReadDirResult, nfsstat3> {
+            Err(nfsstat3::NFS3ERR_NOTSUPP)
+        }
+        async fn symlink(
+            &self,
+            _: fileid3,
+            _: &filename3,
+            _: &nfspath3,
+            _: &sattr3,
+        ) -> Result<(fileid3, fattr3), nfsstat3> {
+            Err(nfsstat3::NFS3ERR_NOTSUPP)
+        }
+        async fn readlink(&self, _: fileid3) -> Result<nfspath3, nfsstat3> {
+            Err(nfsstat3::NFS3ERR_NOTSUPP)
+        }
+    }
+
+    fn test_context() -> RPCContext {
+        RPCContext {
+            local_port: 2049,
+            client_addr: "127.0.0.1:0".to_string(),
+            auth: auth_unix::default(),
+            vfs: Arc::new(NullFS),
+            mount_signal: None,
+            export_name: Arc::new("/".to_string()),
+            transaction_tracker: Arc::new(TransactionTracker::new(Duration::from_secs(60))),
+        }
+    }
+
+    /// Serialize an RPC record (4-byte last-fragment header + body), as
+    /// `write_fragment` does on the wire.
+    fn frame(body: &[u8]) -> Vec<u8> {
+        let header = (body.len() as u32) | (1 << 31);
+        let mut out = header.to_be_bytes().to_vec();
+        out.extend_from_slice(body);
+        out
+    }
+
+    /// Drive a single `MOUNTPROC3_NULL` call through `process_socket` over an
+    /// in-memory `DuplexStream` (not a `TcpStream`) and assert a well-formed
+    /// reply comes back. This proves the handler is genuinely transport-generic
+    /// over `AsyncRead + AsyncWrite + Send + 'static` — the property TLS relies on.
+    #[tokio::test]
+    async fn process_socket_over_non_tcp_stream() {
+        // server side is handed to process_socket; we drive the client side.
+        let (server, mut client) = tokio::io::duplex(64 * 1024);
+
+        let handle = tokio::spawn(async move {
+            let _ = process_socket(server, test_context()).await;
+        });
+
+        // Build a MOUNTPROC3_NULL call (program 100005, version 3, procedure 0).
+        let call = rpc_msg {
+            xid: 0x1234_5678,
+            body: rpc_body::CALL(call_body {
+                rpcvers: 2,
+                prog: crate::mount::PROGRAM,
+                vers: crate::mount::VERSION,
+                proc: 0,
+                cred: opaque_auth::default(),
+                verf: opaque_auth::default(),
+            }),
+        };
+        let mut body = Vec::new();
+        call.serialize(&mut body).unwrap();
+        client.write_all(&frame(&body)).await.unwrap();
+        client.flush().await.unwrap();
+
+        // Read the reply record back: 4-byte fragment header, then the body.
+        let mut header = [0u8; 4];
+        client.read_exact(&mut header).await.unwrap();
+        let len = (u32::from_be_bytes(header) & ((1 << 31) - 1)) as usize;
+        let mut reply_buf = vec![0u8; len];
+        client.read_exact(&mut reply_buf).await.unwrap();
+
+        let mut reply = rpc_msg::default();
+        reply.deserialize(&mut Cursor::new(&reply_buf)).unwrap();
+
+        assert_eq!(reply.xid, 0x1234_5678);
+        match reply.body {
+            rpc_body::REPLY(reply_body::MSG_ACCEPTED(_)) => {},
+            other => panic!("expected an accepted reply, got {other:?}"),
+        }
+
+        // Dropping the client closes the connection so process_socket returns.
+        drop(client);
+        handle.await.unwrap();
     }
 }


### PR DESCRIPTION
## Motivation

We want to serve NFS over connections that aren't a raw `TcpStream` — specifically an already-handshaked TLS stream (`tokio_rustls::server::TlsStream`). Two concrete cases drive this:

- A sidecar terminates mTLS and forwards plaintext, and
- terminating TLS in-process via `tokio-rustls`.

Both need to hand `nfsserve` a stream that isn't a `TcpStream`. Today `process_socket` and `write_fragment` are concretely typed to `tokio::net::TcpStream`, which blocks this. This PR genericizes the per-connection handler over the stream type so callers can bring their own transport, **without `nfsserve` itself taking a TLS dependency**.

## Changes

- **`write_fragment` is now generic** over `W: AsyncWrite + Unpin` (body unchanged — it only used `write_all`).
- **`process_socket` is now generic** over `S: AsyncRead + AsyncWrite + Send + 'static` and is now `pub`, so external callers can serve a pre-established stream. It uses `tokio::io::split` + `AsyncReadExt::read` (cancel-safe in `select!`) in place of the `TcpStream`-specific `readable()`/`try_read()`. (`split` returns `Unpin` halves, so `S` needs no `Unpin` bound.)
- **Replies are now flushed after writing.** A buffering transport (TLS) only encrypts and sends on flush — without it the reply never leaves the server. This is a no-op for raw TCP.
- **`set_nodelay` moved** from `process_socket` into `NFSTcpListener::handle_forever` (it's `TcpStream`-specific). The TCP path keeps `nodelay` behavior unchanged.
- **New test:** drives a `MOUNTPROC3_NULL` RPC through `process_socket` over an in-memory `tokio::io::duplex` stream (which is `AsyncRead + AsyncWrite + Send + 'static`, not a `TcpStream`) and asserts a well-formed reply comes back. This proves the genericization and **adds no new dependency** (no `rustls`), keeping the PR dependency-free.

## Compatibility

`NFSTcpListener` behavior is unchanged and fully backward-compatible — it uses the now-generic `process_socket` internally for plaintext TCP.