### PR TITLE
feat(vfs): let implementations report real FSSTAT values

### DIFF
--- a/src/nfs_handlers.rs
+++ b/src/nfs_handlers.rs
@@ -686,15 +686,26 @@ pub async fn nfsproc3_fsstat(
         Ok(v) => nfs::post_op_attr::attributes(v),
         Err(_) => nfs::post_op_attr::Void,
     };
+
+    let stat = match context.vfs.fsstat(id).await {
+        Ok(stat) => stat,
+        Err(stat) => {
+            make_success_reply(xid).serialize(output)?;
+            stat.serialize(output)?;
+            obj_attr.serialize(output)?;
+            return Ok(());
+        },
+    };
+
     let res = FSSTAT3resok {
         obj_attributes: obj_attr,
-        tbytes: 1024 * 1024 * 1024 * 1024,
-        fbytes: 1024 * 1024 * 1024 * 1024,
-        abytes: 1024 * 1024 * 1024 * 1024,
-        tfiles: 1024 * 1024 * 1024,
-        ffiles: 1024 * 1024 * 1024,
-        afiles: 1024 * 1024 * 1024,
-        invarsec: u32::MAX,
+        tbytes: stat.total_bytes,
+        fbytes: stat.free_bytes,
+        abytes: stat.available_bytes,
+        tfiles: stat.total_files,
+        ffiles: stat.free_files,
+        afiles: stat.available_files,
+        invarsec: stat.invar_sec,
     };
     make_success_reply(xid).serialize(output)?;
     nfs::nfsstat3::NFS3_OK.serialize(output)?;

--- a/src/vfs.rs
+++ b/src/vfs.rs
@@ -64,6 +64,47 @@ pub enum VFSCapabilities {
     ReadWrite,
 }
 
+/// Dynamic file system statistics, as reported by the NFS `FSSTAT` procedure.
+///
+/// These are the numbers a client shows for `df`.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct FsStat {
+    /// Total size of the file system, in bytes.
+    pub total_bytes: u64,
+    /// Free space, in bytes.
+    pub free_bytes: u64,
+    /// Free space available to the user the request is made on behalf of, in bytes. For a read-only
+    /// file system this is normally zero.
+    pub available_bytes: u64,
+    /// Total number of file slots.
+    pub total_files: u64,
+    /// Number of free file slots.
+    pub free_files: u64,
+    /// Number of free file slots available to the user the request is made on behalf of.
+    pub available_files: u64,
+    /// Number of seconds for which the server guarantees these values will not change. `u32::MAX`
+    /// means no such guarantee is made.
+    pub invar_sec: u32,
+}
+
+impl Default for FsStat {
+    /// The placeholder values the server reported before [`NFSFileSystem::fsstat`] existed: 1 TiB
+    /// of space and 1 Gi file slots, all of it free.
+    fn default() -> Self {
+        const TIB: u64 = 1024 * 1024 * 1024 * 1024;
+        const GI: u64 = 1024 * 1024 * 1024;
+        Self {
+            total_bytes: TIB,
+            free_bytes: TIB,
+            available_bytes: TIB,
+            total_files: GI,
+            free_files: GI,
+            available_files: GI,
+            invar_sec: u32::MAX,
+        }
+    }
+}
+
 /// The basic API to implement to provide an NFS file system
 ///
 /// Opaque FH
@@ -192,6 +233,18 @@ pub trait NFSFileSystem: Sync {
     /// Reads a symlink
     async fn readlink(&self, id: fileid3) -> Result<nfspath3, nfsstat3>;
 
+    /// Get dynamic file system statistics: how much space and how many file slots the file system
+    /// has, and how much of that is free. This is what a client reports for `df`.
+    ///
+    /// The default implementation returns [`FsStat::default`], which is a placeholder claiming 1
+    /// TiB of entirely free space. Override it to report the real numbers for the backing store;
+    /// otherwise clients will show a wrong capacity, and a read-only file system will appear to
+    /// have room to write into.
+    async fn fsstat(&self, root_fileid: fileid3) -> Result<FsStat, nfsstat3> {
+        let _ = root_fileid;
+        Ok(FsStat::default())
+    }
+
     /// Get static file system Information
     async fn fsinfo(&self, root_fileid: fileid3) -> Result<fsinfo3, nfsstat3> {
         let dir_attr: nfs::post_op_attr = match self.getattr(root_fileid).await {
@@ -257,5 +310,24 @@ pub trait NFSFileSystem: Sync {
     fn serverid(&self) -> cookieverf3 {
         let gennum = get_generation_number();
         gennum.to_le_bytes()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The default must keep reporting exactly what the server hardcoded before `fsstat` became
+    /// overridable, so that existing implementations of [`NFSFileSystem`] see no behaviour change.
+    #[test]
+    fn fsstat_default_matches_previous_hardcoded_values() {
+        let stat = FsStat::default();
+        assert_eq!(stat.total_bytes, 1024 * 1024 * 1024 * 1024);
+        assert_eq!(stat.free_bytes, 1024 * 1024 * 1024 * 1024);
+        assert_eq!(stat.available_bytes, 1024 * 1024 * 1024 * 1024);
+        assert_eq!(stat.total_files, 1024 * 1024 * 1024);
+        assert_eq!(stat.free_files, 1024 * 1024 * 1024);
+        assert_eq!(stat.available_files, 1024 * 1024 * 1024);
+        assert_eq!(stat.invar_sec, u32::MAX);
     }
 }

--- a/src/vfs.rs
+++ b/src/vfs.rs
@@ -82,14 +82,17 @@ pub struct FsStat {
     pub free_files: u64,
     /// Number of free file slots available to the user the request is made on behalf of.
     pub available_files: u64,
-    /// Number of seconds for which the server guarantees these values will not change. `u32::MAX`
-    /// means no such guarantee is made.
+    /// Number of seconds for which the file system is not expected to change, per RFC 1813
+    /// §3.3.18: zero for a volatile file system, and "for an immutable file system, such as a
+    /// CD-ROM, this would be the largest unsigned integer" — so `u32::MAX` advertises that the
+    /// file system does not change, which is what a read-only export wants.
     pub invar_sec: u32,
 }
 
 impl Default for FsStat {
     /// The placeholder values the server reported before [`NFSFileSystem::fsstat`] existed: 1 TiB
-    /// of space and 1 Gi file slots, all of it free.
+    /// of space and 1 Gi file slots, all of it free, and an `invar_sec` claiming the file system
+    /// never changes.
     fn default() -> Self {
         const TIB: u64 = 1024 * 1024 * 1024 * 1024;
         const GI: u64 = 1024 * 1024 * 1024;


### PR DESCRIPTION
### Problem

`nfsproc3_fsstat` hardcodes its reply:

```rust
tbytes: 1024 * 1024 * 1024 * 1024,
fbytes: 1024 * 1024 * 1024 * 1024,
abytes: 1024 * 1024 * 1024 * 1024,
tfiles: 1024 * 1024 * 1024,
...
```

There is no hook on `NFSFileSystem` to override it, so every nfsserve-backed file system reports a 1 TiB volume with 1 TiB free. Two consequences:

- `df` and the client's file manager show a capacity unrelated to the backing store.
- A `VFSCapabilities::ReadOnly` file system advertises a terabyte of available space, which reads as "you can write here" right up until the write fails.

I hit this exposing a read-only ext4 volume on macOS: the real volume is 3.6 TiB with 559 GiB used, and Finder showed 1 TB free.

### Change

- New `FsStat` type carrying the six FSSTAT size fields plus `invarsec`.
- New `NFSFileSystem::fsstat(&self, root_fileid) -> Result<FsStat, nfsstat3>`, with a default implementation returning `FsStat::default()`.
- `FsStat::default()` is **exactly** the previous hardcoded values, so this is a no-op for every existing implementation — no trait method to add, no behaviour change unless you opt in.
- The handler propagates an `Err` from `fsstat` the same way it already propagates a bad file handle: status plus the object attributes it had already resolved.

A unit test pins the default values, so the backwards-compatibility promise cannot regress silently. (This is the first test in the crate; happy to move it elsewhere if you would rather keep `src/` test-free.)

### Testing

The CI steps pass locally:

- `cargo +nightly fmt --all -- --check`
- `cargo clippy -r --verbose -- -D warnings`
- `cargo test --no-fail-fast --features "strict"`
- `Cargo.lock` unchanged

I am wiring this into the read-only ext4 server described above and will follow up here with the `df` output from the macOS NFS client once that is running against this branch.