### PR TITLE
feat(vfs): give directory entries an explicit pagination cookie

### DIFF
--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -275,19 +275,23 @@ impl NFSFileSystem for DemoFS {
             };
             let mut start_index = 0;
             if start_after > 0 {
-                if let Some(pos) = dir.iter().position(|&r| r == start_after) {
-                    start_index = pos + 1;
-                } else {
+                // The cookie is a one-based position, so it is also the index of the
+                // next entry to serve.
+                start_index = start_after as usize;
+                if start_index > dir.len() {
                     return Err(nfsstat3::NFS3ERR_BAD_COOKIE);
                 }
             }
             let remaining_length = dir.len() - start_index;
 
-            for i in dir[start_index..].iter() {
+            for (offset, i) in dir[start_index..].iter().enumerate() {
                 ret.entries.push(DirEntry {
                     fileid: *i,
                     name: fs[(*i) as usize].name.clone(),
                     attr: fs[(*i) as usize].attr,
+                    // Position in the listing, one-based so zero stays reserved for
+                    // "start at the beginning".
+                    cookie: (start_index + offset + 1) as u64,
                 });
                 if ret.entries.len() >= max_entries {
                     break;

--- a/examples/mirrorfs.rs
+++ b/examples/mirrorfs.rs
@@ -394,7 +394,7 @@ impl NFSFileSystem for MirrorFS {
         debug!("path: {:?}", path);
         debug!("children len: {:?}", children.len());
         debug!("remaining_len : {:?}", remaining_length);
-        for i in children.range((range_start, Bound::Unbounded)) {
+        for (offset, i) in children.range((range_start, Bound::Unbounded)).enumerate() {
             let fileid = *i;
             let fileent = fsmap.find_entry(fileid)?;
             let name = fsmap.sym_to_fname(&fileent.name).await;
@@ -403,7 +403,12 @@ impl NFSFileSystem for MirrorFS {
                 fileid,
                 name: name.as_bytes().into(),
                 attr: fileent.fsmeta,
+                // This example paginates by fileid, so keeping the fileid as the
+                // cookie preserves its existing behaviour; `offset` is available if
+                // a positional cookie is preferred.
+                cookie: fileid,
             });
+            let _ = offset;
             if ret.entries.len() >= max_entries {
                 break;
             }

--- a/src/nfs_handlers.rs
+++ b/src/nfs_handlers.rs
@@ -686,15 +686,26 @@ pub async fn nfsproc3_fsstat(
         Ok(v) => nfs::post_op_attr::attributes(v),
         Err(_) => nfs::post_op_attr::Void,
     };
+
+    let stat = match context.vfs.fsstat(id).await {
+        Ok(stat) => stat,
+        Err(stat) => {
+            make_success_reply(xid).serialize(output)?;
+            stat.serialize(output)?;
+            obj_attr.serialize(output)?;
+            return Ok(());
+        },
+    };
+
     let res = FSSTAT3resok {
         obj_attributes: obj_attr,
-        tbytes: 1024 * 1024 * 1024 * 1024,
-        fbytes: 1024 * 1024 * 1024 * 1024,
-        abytes: 1024 * 1024 * 1024 * 1024,
-        tfiles: 1024 * 1024 * 1024,
-        ffiles: 1024 * 1024 * 1024,
-        afiles: 1024 * 1024 * 1024,
-        invarsec: u32::MAX,
+        tbytes: stat.total_bytes,
+        fbytes: stat.free_bytes,
+        abytes: stat.available_bytes,
+        tfiles: stat.total_files,
+        ffiles: stat.free_files,
+        afiles: stat.available_files,
+        invarsec: stat.invar_sec,
     };
     make_success_reply(xid).serialize(output)?;
     nfs::nfsstat3::NFS3_OK.serialize(output)?;

--- a/src/nfs_handlers.rs
+++ b/src/nfs_handlers.rs
@@ -904,7 +904,7 @@ pub async fn nfsproc3_readdirplus(
                 let entry = entryplus3 {
                     fileid: entry.fileid,
                     name: entry.name,
-                    cookie: entry.fileid,
+                    cookie: entry.cookie,
                     name_attributes: nfs::post_op_attr::attributes(obj_attr),
                     name_handle: handle,
                 };
@@ -1025,7 +1025,7 @@ pub async fn nfsproc3_readdir(
                 let entry = entry3 {
                     fileid: entry.fileid,
                     name: entry.name,
-                    cookie: entry.fileid,
+                    cookie: entry.cookie,
                 };
                 // write the entry into a buffer first
                 let mut write_buf: Vec<u8> = Vec::new();

--- a/src/vfs.rs
+++ b/src/vfs.rs
@@ -10,6 +10,8 @@ use crate::nfs::*;
 pub struct DirEntrySimple {
     pub fileid: fileid3,
     pub name: filename3,
+    /// Pagination cookie; see [`DirEntry::cookie`].
+    pub cookie: u64,
 }
 #[derive(Default, Debug)]
 pub struct ReadDirSimpleResult {
@@ -22,6 +24,21 @@ pub struct DirEntry {
     pub fileid: fileid3,
     pub name: filename3,
     pub attr: fattr3,
+    /// Pagination cookie for this entry, echoed back by the client in the next
+    /// `readdir` as `start_after`.
+    ///
+    /// This used to be the `fileid`, which cannot work in general: a fileid is not
+    /// unique within a directory. Hard links share one, and so do `.` and `..` in a
+    /// file system's root. When the server truncates a reply to its byte budget the
+    /// client resumes from the last entry it actually received, so an ambiguous
+    /// cookie either rewinds the listing or skips the entries in between — silently,
+    /// with eof set. RFC 1813 §3.3.16 makes the cookie server-opaque precisely so an
+    /// implementation can use a position instead of an identity.
+    ///
+    /// Set it to anything that uniquely identifies the entry's position in the
+    /// listing; an index is the obvious choice. Zero is reserved: the client sends
+    /// cookie 0 to mean "start at the beginning".
+    pub cookie: u64,
 }
 #[derive(Default, Debug)]
 pub struct ReadDirResult {
@@ -37,6 +54,7 @@ impl ReadDirSimpleResult {
             .map(|e| DirEntrySimple {
                 fileid: e.fileid,
                 name: e.name.clone(),
+                cookie: e.cookie,
             })
             .collect();
         ReadDirSimpleResult {

--- a/src/vfs.rs
+++ b/src/vfs.rs
@@ -64,6 +64,47 @@ pub enum VFSCapabilities {
     ReadWrite,
 }
 
+/// Dynamic file system statistics, as reported by the NFS `FSSTAT` procedure.
+///
+/// These are the numbers a client shows for `df`.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct FsStat {
+    /// Total size of the file system, in bytes.
+    pub total_bytes: u64,
+    /// Free space, in bytes.
+    pub free_bytes: u64,
+    /// Free space available to the user the request is made on behalf of, in bytes. For a read-only
+    /// file system this is normally zero.
+    pub available_bytes: u64,
+    /// Total number of file slots.
+    pub total_files: u64,
+    /// Number of free file slots.
+    pub free_files: u64,
+    /// Number of free file slots available to the user the request is made on behalf of.
+    pub available_files: u64,
+    /// Number of seconds for which the server guarantees these values will not change. `u32::MAX`
+    /// means no such guarantee is made.
+    pub invar_sec: u32,
+}
+
+impl Default for FsStat {
+    /// The placeholder values the server reported before [`NFSFileSystem::fsstat`] existed: 1 TiB
+    /// of space and 1 Gi file slots, all of it free.
+    fn default() -> Self {
+        const TIB: u64 = 1024 * 1024 * 1024 * 1024;
+        const GI: u64 = 1024 * 1024 * 1024;
+        Self {
+            total_bytes: TIB,
+            free_bytes: TIB,
+            available_bytes: TIB,
+            total_files: GI,
+            free_files: GI,
+            available_files: GI,
+            invar_sec: u32::MAX,
+        }
+    }
+}
+
 /// The basic API to implement to provide an NFS file system
 ///
 /// Opaque FH
@@ -192,6 +233,18 @@ pub trait NFSFileSystem: Sync {
     /// Reads a symlink
     async fn readlink(&self, id: fileid3) -> Result<nfspath3, nfsstat3>;
 
+    /// Get dynamic file system statistics: how much space and how many file slots the file system
+    /// has, and how much of that is free. This is what a client reports for `df`.
+    ///
+    /// The default implementation returns [`FsStat::default`], which is a placeholder claiming 1
+    /// TiB of entirely free space. Override it to report the real numbers for the backing store;
+    /// otherwise clients will show a wrong capacity, and a read-only file system will appear to
+    /// have room to write into.
+    async fn fsstat(&self, root_fileid: fileid3) -> Result<FsStat, nfsstat3> {
+        let _ = root_fileid;
+        Ok(FsStat::default())
+    }
+
     /// Get static file system Information
     async fn fsinfo(&self, root_fileid: fileid3) -> Result<fsinfo3, nfsstat3> {
         let dir_attr: nfs::post_op_attr = match self.getattr(root_fileid).await {
@@ -257,5 +310,24 @@ pub trait NFSFileSystem: Sync {
     fn serverid(&self) -> cookieverf3 {
         let gennum = get_generation_number();
         gennum.to_le_bytes()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The default must keep reporting exactly what the server hardcoded before `fsstat` became
+    /// overridable, so that existing implementations of [`NFSFileSystem`] see no behaviour change.
+    #[test]
+    fn fsstat_default_matches_previous_hardcoded_values() {
+        let stat = FsStat::default();
+        assert_eq!(stat.total_bytes, 1024 * 1024 * 1024 * 1024);
+        assert_eq!(stat.free_bytes, 1024 * 1024 * 1024 * 1024);
+        assert_eq!(stat.available_bytes, 1024 * 1024 * 1024 * 1024);
+        assert_eq!(stat.total_files, 1024 * 1024 * 1024);
+        assert_eq!(stat.free_files, 1024 * 1024 * 1024);
+        assert_eq!(stat.available_files, 1024 * 1024 * 1024);
+        assert_eq!(stat.invar_sec, u32::MAX);
     }
 }

--- a/src/vfs.rs
+++ b/src/vfs.rs
@@ -82,14 +82,17 @@ pub struct FsStat {
     pub free_files: u64,
     /// Number of free file slots available to the user the request is made on behalf of.
     pub available_files: u64,
-    /// Number of seconds for which the server guarantees these values will not change. `u32::MAX`
-    /// means no such guarantee is made.
+    /// Number of seconds for which the file system is not expected to change, per RFC 1813
+    /// §3.3.18: zero for a volatile file system, and "for an immutable file system, such as a
+    /// CD-ROM, this would be the largest unsigned integer" — so `u32::MAX` advertises that the
+    /// file system does not change, which is what a read-only export wants.
     pub invar_sec: u32,
 }
 
 impl Default for FsStat {
     /// The placeholder values the server reported before [`NFSFileSystem::fsstat`] existed: 1 TiB
-    /// of space and 1 Gi file slots, all of it free.
+    /// of space and 1 Gi file slots, all of it free, and an `invar_sec` claiming the file system
+    /// never changes.
     fn default() -> Self {
         const TIB: u64 = 1024 * 1024 * 1024 * 1024;
         const GI: u64 = 1024 * 1024 * 1024;


### PR DESCRIPTION
Stacked on #48 (same branch lineage; that PR only adds the `fsstat` hook and is independent of this one).

### Problem

Both readdir handlers use the entry's fileid as the wire cookie:

```rust
cookie: entry.fileid,
```

A fileid is not unique within a directory. Hard links share one, and `.` and `..` in a file system root share the root's fileid on every volume. Meanwhile the handler truncates the reply to `dircount`/`maxcount` and reports `eof = false`, so the client resumes from the last entry it *actually received*, which can be earlier than the last entry the VFS returned.

That makes an ambiguous cookie unresolvable by the VFS:

- resolve it to the **first** match and the listing rewinds — the client re-reads a window forever;
- resolve it to the **last** match and every entry between the client's real position and that match is skipped, and `eof` is eventually set.

The second is the dangerous one: a directory listing that silently omits real files. A `cp -r` or `rsync` over such a mount finishes reporting success.

I hit this implementing a read-only ext4 server. Reproduced on a real image with `f0..f5` plus `zlink` hard-linked to `f0`: page 1 returned 9 entries, the client's last received entry was `f0`, and the next page came back empty with `eof = true` — `f1`..`f5` and `zlink` gone. The root directory reproduces the `.`/`..` variant on any volume.

### Change

RFC 1813 §3.3.16 makes the cookie server-opaque precisely so an implementation can use a *position* instead of an *identity*. This adds a `cookie` field to `DirEntry` and `DirEntrySimple` and has both handlers echo it, so a VFS can hand out an index and paginate unambiguously.

It also removes the need for the `BAD_COOKIE` dance the trait docs warn about: a positional cookie needs no lookup, so an evicted or rebuilt listing costs a rebuild rather than a rewind.

### On the breaking change

Widening the struct breaks implementations that construct `DirEntry`, which is why this is a separate commit from #48 — the bug cannot be fixed without it. Migration is one line per construction site, and `cookie: fileid` reproduces today's behaviour exactly, so nobody is forced to change semantics in the same step.

`examples/demo.rs` moves to a one-based positional cookie and drops its `BAD_COOKIE` fallback; `examples/mirrorfs.rs` keeps fileid cookies deliberately, to show that the old behaviour still expresses.

### Testing

- `cargo +nightly fmt --all -- --check`
- `cargo clippy -r --verbose -- -D warnings` (and `--all-targets`)
- `cargo test --no-fail-fast --features "strict"`
- `Cargo.lock` unchanged

Verified downstream against the macOS NFS client: with positional cookies, a directory containing a hard-link pair and the root's `.`/`..` both enumerate exactly once with no omissions, where the same fixture previously dropped a run of entries.